### PR TITLE
progress bar

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -2,3 +2,4 @@
 @import "alert";
 @import "avatar";
 @import "navbar";
+@import "progress_bar";

--- a/app/assets/stylesheets/components/_progress_bar.scss
+++ b/app/assets/stylesheets/components/_progress_bar.scss
@@ -1,7 +1,7 @@
 // This is the outside container.
 .path-progress {
   display: flex;
-  i {
+  .iconify {
     font-size: 108px;
     // margin-top: 34px;
     // margin-bottom: 33px;

--- a/app/assets/stylesheets/components/_progress_bar.scss
+++ b/app/assets/stylesheets/components/_progress_bar.scss
@@ -1,0 +1,33 @@
+// This is the outside container.
+.path-progress {
+  display: flex;
+  i {
+    font-size: 108px;
+    // margin-top: 34px;
+    // margin-bottom: 33px;
+    color: #E6E6E6;
+    flex-basis: auto;
+    margin-left: 46px;
+  }
+}
+
+// this is a bootstrap class for the container of the progress bar,
+// which I have modified
+.progress {
+  height: 41px;
+  margin-top: 34px;
+  margin-bottom: 33px;
+  border-radius: 30px;
+  background-color: #E6E6E6;
+  // width: 90%;
+  flex-grow: 2;
+}
+
+// this is a bootstrap class for the part of the progress-bar
+// that shows the actual progress
+.progress-bar {
+  background-color: $reward;
+  color: $text-color;
+}
+
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_many :paths, through: :step_progresses
   has_many :users_learning_groups, dependent: :destroy
   has_one :codewars_profile, dependent: :destroy
+  has_many :step_progresses
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css">
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
   </head>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,8 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css">
+    <!-- <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css"> -->
+    <script src="https://code.iconify.design/1/1.0.7/iconify.min.js"></script>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
   </head>
 

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,4 @@
 <h1>Pages#home</h1>
 <p>Find me in app/views/pages/home.html.erb</p>
 <p>Hello World</p>
+<%= render 'shared/progress_bar' %>

--- a/app/views/shared/_progress_bar.html.erb
+++ b/app/views/shared/_progress_bar.html.erb
@@ -1,8 +1,9 @@
 <div class="path-progress">
-<div class="progress">
-  <div class="progress-bar" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">50%</div>
-</div>
-<i class="fas fa-trophy" ></i>
+  <div class="progress">
+    <div class="progress-bar" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">50%</div>
+  </div>
+  <!-- <i class="fas fa-trophy" ></i> -->
+  <span class="iconify" data-icon="si-glyph:champion-cup" data-inline="false"></span>
 </div>
 
 <%# hourly_sum = 0

--- a/app/views/shared/_progress_bar.html.erb
+++ b/app/views/shared/_progress_bar.html.erb
@@ -1,0 +1,24 @@
+<div class="path-progress">
+<div class="progress">
+  <div class="progress-bar" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">50%</div>
+</div>
+<i class="fas fa-trophy" ></i>
+</div>
+
+<%# hourly_sum = 0
+Path.find(1).steps.each do |s|
+hourly_sum += s.duration
+end %>
+
+<%# progress_sum = 0
+User.find(1).where(path_id: 1, completion: true).each do |p|
+progress_sum += p.step.duration
+end
+ %>
+
+<%# progress_percentage = ((progress_sum.to_f / hourly_sum.to_f)*100).round %>
+
+
+<%# // the progress-bar width should be set in an inline-style in the "progress"
+// container, unless if it is determined automatically through a surrounding
+// container. %>


### PR DESCRIPTION
UPDATE: added iconify instead of fontawesome
![Bildschirmfoto 2021-02-23 um 19 37 31](https://user-images.githubusercontent.com/17951950/108891094-95d02d00-760e-11eb-9f09-b3b7835d5169.png)

----

![Bildschirmfoto 2021-02-20 um 16 58 09](https://user-images.githubusercontent.com/17951950/108601446-e93b4480-739c-11eb-8aa2-c1a12ce6f5ef.png)
I have included the progress bar on the "home" page for display purposes. It covers the entire page here, because there is no limiting container on this "home" page. On our actual pages it would just cover the width of the page-container.

I took the only trophy-icon that was free on fontawesome.

The display of the percentage on the progress bar might be smaller than specified in figma. I did not adapt that because the p font styles are defined globally and I did not want to change them for this percentage display. We might decide to tweak that in the end, but for now I thought it's ok like that.

There is no dynamic logic steering the displayed progress yet. I have figured out the methods, but not inserted them anywhere yet. The proper way would be to write that in JS, which I don't know how to do it and would leave it for next week. Or we will need to either insert them into each controller where the progress bar is displayed, which I would leave for whenever those controllers are final.

For now the 50% displayed in the progress bar correlates with the 50% in our seed file, so.... :-D :-D