### PR TITLE
progress-dependent behavior on step page + progress bar + front end

### DIFF
--- a/app/assets/stylesheets/components/_progress_bar.scss
+++ b/app/assets/stylesheets/components/_progress_bar.scss
@@ -1,6 +1,7 @@
 // This is the outside container.
 .path-progress {
   display: flex;
+  margin: 36px 0;
   .iconify {
     font-size: 108px;
     // margin-top: 34px;

--- a/app/assets/stylesheets/components/_step_card.scss
+++ b/app/assets/stylesheets/components/_step_card.scss
@@ -3,13 +3,23 @@
   height: 124px;
   display: flex;
   align-items: center;
-  border-bottom: 2px solid #D1D3D4;
+  border-bottom: 2px solid #CCC;
+  transition: 0.15s ease;
   &:hover {
     cursor: pointer;
+    transform: scale(1.01);
   }
 }
 
-.step-card-logo {
+.step-card-completed-icon {
+  color: $reward;
+}
+
+.step-card-todo-icon {
+  color: $warn;
+}
+
+.step-card-logo-container {
   padding: 0 34px;
   .logo {
     color: $alert;
@@ -18,7 +28,6 @@
 }
 
 .step-card-text {
-
   .completion {
     margin-bottom: 0;
   }
@@ -29,7 +38,6 @@
   font-size: 52px;
   margin-right: 34px;
   margin-left: auto;
-  transform: rotate(-90deg);
   transition: 0.2s ease;
 }
 
@@ -39,7 +47,22 @@
   padding-left: 140px;
   padding-right: 36px;
   padding-top: 36px;
-  border: 1px solid $text-color;
+  border: 2px solid $text-color;
+}
+
+.step-duration {
+  display: flex;
+  align-items: center;
+}
+
+.step-duration-symbol {
+  font-size: 28px;
+  margin-right: 12px;
+}
+
+.step-duration-number {
+  display: inline;
+  font-weight: bold;
 }
 
 .btn-accordion {
@@ -47,10 +70,31 @@
 }
 
 // taking effect when the card gets expanded
+.step-card-closed-part-expanded {
+  border-bottom: 2px solid transparent;
+
+}
+
 .step-card-expanded-part-expanded {
   display: flex;
 }
 
 .step-card-expand-icon-expanded {
-  transform: none;
+  transform: rotate(180deg);
 }
+
+// color changes when the step is completed
+.step-card-expand-icon-completed {
+  color: #CCC;
+}
+
+.step-card-logo-completed {
+  color: #CCC;
+}
+
+.step-card-logo-container {
+  .logo-completed {
+    color: #CCC;
+  }
+}
+

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -11,7 +11,8 @@ $light-gray: #F4F4F4;
 
 // Brand colors
 
-$bg-white: #E5E5E5;
+// $bg-white: #E5E5E5;
+$bg-white: white;
 $cb-white: #F8F4FF;
 $text-color: #003366;
 $hero-color: #A9DCDB;

--- a/app/assets/stylesheets/config/_global.scss
+++ b/app/assets/stylesheets/config/_global.scss
@@ -6,8 +6,7 @@ h1{
 }
 
 body {
-  // background-color: $bg-white;
-  background-color: $cb-white;
+  background-color: $bg-white;
 }
 
 h2 {

--- a/app/assets/stylesheets/config/_global.scss
+++ b/app/assets/stylesheets/config/_global.scss
@@ -6,7 +6,8 @@ h1{
 }
 
 body {
-  background-color: $bg-white;
+  // background-color: $bg-white;
+  background-color: $cb-white;
 }
 
 h2 {

--- a/app/assets/stylesheets/pages/_layout.scss
+++ b/app/assets/stylesheets/pages/_layout.scss
@@ -1,5 +1,4 @@
 // path#show
-
 .path-show-page-container{
   width: 100%;
   display: flex;
@@ -11,4 +10,3 @@
 .path-show-page-middle-container {
   width: 1120px;
 }
-

--- a/app/controllers/paths_controller.rb
+++ b/app/controllers/paths_controller.rb
@@ -8,6 +8,26 @@ class PathsController < ApplicationController
   def show
     authorize @path = Path.find_by_id(params[:id])
     @steps = @path.steps
-    @step_progresses = @path.step_progresses.where(user_id: current_user.id)
+    step_progresses = @path.step_progresses.where(user_id: current_user.id)
+
+    @step_data = {}
+    @steps.each do |step|
+      id = step.id
+      completion = step_progresses.where(step_id: id).first.completion
+      duration = step.duration
+      if duration < 60
+        duration_string = "#{duration} minutes"
+      elsif (duration % 60).zero?
+        duration_hours = duration / 60
+        duration_string = pluralize(duration_hours, 'hour').to_s
+      else
+        duration_string = "#{duration.fdiv(60).round(1)} hours"
+      end
+
+      @step_data[id] = {
+        completion: completion,
+        duration: duration_string
+      }
+    end
   end
 end

--- a/app/javascript/custom/step_card_toggle_expanded.js
+++ b/app/javascript/custom/step_card_toggle_expanded.js
@@ -4,18 +4,18 @@ const initStepCardEventListener = () => {
 
   for (var i = 0; i < stepCards.length; i++) {
     let stepCard = stepCards[i];
-    // console.log(stepCard);
     let closedPart = stepCard.getElementsByClassName('step-card-closed-part')[0];
     console.log(closedPart);
     closedPart.addEventListener('click', (event) => {
 
       let expandedPart = stepCard.getElementsByClassName('step-card-expanded-part')[0];
       expandedPart.classList.toggle('step-card-expanded-part-expanded');
-        // console.log(expandedPart);
 
       let expandIcon = stepCard.getElementsByClassName('step-card-expand-icon')[0];
-      console.log(expandIcon);
       expandIcon.classList.toggle('step-card-expand-icon-expanded');
+
+      let closedPart = stepCard.getElementsByClassName('step-card-closed-part')[0];
+      closedPart.classList.toggle('step-card-closed-part-expanded');
   });
   }
 };

--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -5,10 +5,14 @@
   </div>
 
   <div class="path-show-page-middle-container">
-     <%#= render 'shared/progress_bar' %>
+     <%= render 'shared/progress_bar' %>
      <div class="steps-container">
         <% @steps.each do |step| %>
-          <%= render 'shared/step_card', locals: { step: step } %>
+          <%= render 'shared/step_card',
+          locals: {
+            step: step,
+            completed: @step_data[step.id][:completion],
+            duration: @step_data[step.id][:duration] } %>
         <% end %>
      </div>
   </div>

--- a/app/views/shared/_btn_accordion.html.erb
+++ b/app/views/shared/_btn_accordion.html.erb
@@ -1,9 +1,11 @@
-<!-- This link is HARD CODED (for starters) -->
-<a href="https://www.codecademy.com/courses/react-101/lessons/react-components-advanced-jsx/exercises/render-multiline-jsx" class="btn-accordion-link-wrapper">
+<a href=<%= locals[:url] %>, class="btn-accordion-link-wrapper">
   <div class="btn-accordion">
     <div class="btn-accordion-text">
-        <!-- ToDo: Need to pass the step's progress in order to show the correct text -->
+      <% if locals[:completed] %>
+        Start again
+      <% else %>
         Start
+      <% end %>
     </div>
   </div>
 </a>

--- a/app/views/shared/_step_card.html.erb
+++ b/app/views/shared/_step_card.html.erb
@@ -1,40 +1,49 @@
 <script src="https://code.iconify.design/1/1.0.6/iconify.min.js"></script>
 
-<!-- I think we need ONE card and an event listener for the expand-button which toggles the class
-e.g. "expanded" on this card. Then the logic what gets displayed in this card is done here in this ONE component -->
-
 <div class="step-card-container">
 
   <div class="step-card-closed-part">
 
-    <div class="step-card-logo">
-      <span class="iconify logo" data-inline="false" data-icon="ph:path-bold"></span>
+    <div class="step-card-logo-container">
+      <span class="iconify logo <%= 'logo-completed' if locals[:completed] %>"
+      data-inline="false" data-icon="ph:path-bold"></span>
     </div>
 
     <div class="step-card-text">
       <h5><%= locals[:step].title %></h5>
-      <!-- ToDo: display either "completed" or "to do" -->
-      <p class="completion"><i class="fas fa-circle"></i> TO DO</p>
-      <!-- <p class="completion"><i class="fas fa-check-circle"></i> Completed</p> -->
+      <% if locals[:completed] %>
+        <p class="completion"><i class="fas fa-check-circle step-card-completed-icon"></i> Completed</p>
+      <% else %>
+        <p class="completion"><i class="fas fa-circle step-card-todo-icon"></i> TO DO</p>
+      <% end %>
     </div>
 
-    <!-- ToDo: display either arrow right or arrow down -->
-    <div class="step-card-expand-icon">
+    <div class="step-card-expand-icon <%= 'step-card-expand-icon-completed' if locals[:completed] %>">
       <i class="fas fa-angle-down"></i>
     </div>
 
   </div>
 
-
   <div class="step-card-expanded-part">
 
     <div class="step-card-description">
-      <i class="far fa-calendar-check"></i>
+      <div class="step-duration">
+        <div>
+          <i class="far fa-calendar-check step-duration-symbol"></i>
+        </div>
+        <div>
+          <p class="step-duration-number"><%= locals[:duration] %></p>
+        </div>
+      </div>
       <p><%= locals[:step].description %></p>
     </div>
 
     <div class="btn-accordion-container">
-      <%= render 'shared/btn_accordion' %>
+      <%= render 'shared/btn_accordion',
+      locals: {
+        completed: locals[:completed],
+        url: locals[:step].url
+      } %>
     </div>
 
   </div>


### PR DESCRIPTION
tl;dr: refinements on path showpage, front- and back-end + progress bar

- include progress bar (width to be edited)
- add hover effect (scale) to step
- add step's status (completed / todo)
- adjust symbol color based on step status
- adjust button text based on step status
- url to external learning soruce (button) is now dynamic
- minor frontend changes (see following)

I made some minor front end decisions which differ from figma. Let me know what you think:
1. every page's background is now white, i.e. I changed $bg-white to white. I just wanted to test a lighter color since we got the feedback that the grey looks kind of odd and I agree. What do you think? ("let's discuss colors"). We don't have to stick to white white though
2. the expand arrow points downwards when card collapsed and upwards otherwise (figma: right wenn collapsed, down when expanded)
3. the border of the expanded card is now 2px (figma: 1px) so it matches the grey border's width between collapsed cards
4. the distance between the calendar symbol and the duration is 12px (figma: 20px)
5. the step card's symbol's and expand icon's color depends on the step's status (figma: whether it's expanded or not). This makes it in my eyes clearer which step comes next

![clp_step_page_progress_behavior](https://user-images.githubusercontent.com/60707819/109361372-1dc16b80-7889-11eb-84c5-96ca5dfa5062.gif)


