### PR TITLE
Navbar fixes

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -22,6 +22,6 @@
 .avatar-nav {
   width: 65px;
   border-radius: 50%;
-  border: 4px solid #003366;
+  // border: 1px solid #003366;
   box-sizing: border-box;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,10 +6,12 @@
     <%= csp_meta_tag %>
 
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <script src="https://code.iconify.design/1/1.0.7/iconify.min.js"></script>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <!-- <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css"> -->
-    <script src="https://code.iconify.design/1/1.0.7/iconify.min.js"></script>
+
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
+
   </head>
 
   <body>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -29,7 +29,8 @@
         <li class="nav-item dropdown">
           <%# INSERT PROPER USER ICON INSTEAD OF SSAUNIER PROFILE PIC%>
           <%# image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar-nav dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
-          <%= cl_image_tag("Home/profile-avatar_gdki3u.png", :className=>"avatar-nav dropdown-toggle", width: 65, height: 65, crop: :scale)%>
+          <%= image_tag "http://res.cloudinary.com/dqopwdgta/image/upload/c_fill,h_65,w_65/v1/Home/profile-avatar_gdki3u.png", class: "avatar-nav dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+          <!-- <span class: "dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" } ><%= cl_image_tag("Home/profile-avatar_gdki3u.png", :className=>"avatar-nav dropdown-toggle", width: 65, height: 65, crop: :fill)%></span> -->
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
             <%# INSERT LINK TO USER PROFILE HERE%>
             <%= link_to "Profile", "#", class: "dropdown-item" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -6,7 +6,7 @@
       <%# image_tag "https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/logo.png" %>
       <span class="iconify logo" data-inline="false" data-icon="ph:path-bold" style="font-size: 35px"></span>
     <% end %>
-    <%= link_to "CATALOGUE", paths_path, class: "navbar-h3"  %>
+    <%= link_to "ALL PATHS", paths_path, class: "navbar-h3"  %>
   </div>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
I couldn't figure out how to apply the bootstrap JS that makes the dropdown work to the cloudinary tag, so I used a normal image tag and included the long cloudinary url. I hope that works on heroku... we will see.
I did not delete the CATALOGUE on the left, but replaced it with ALL PATHS. Otherwise it destroys the symmetry.
I have not added any links to the logo.
The TA didn't find a solution for the iconify load problem either. We either live with it or we replace the images with images we upload to cloudinary. I would suggest we just live with it for now.
![Bildschirmfoto 2021-02-27 um 13 00 12](https://user-images.githubusercontent.com/17951950/109386561-be507380-78fb-11eb-8056-7a841cb18afa.png)
