### PR TITLE
step show page: learning group button complete

### DIFF
--- a/app/assets/stylesheets/components/_learning_group_box.scss
+++ b/app/assets/stylesheets/components/_learning_group_box.scss
@@ -1,10 +1,28 @@
-.learning-group-box-container {
+.join-learning-group-link-wrapper:hover {
+  text-decoration: none;
+}
+
+.learning-group-box-container, .learning-group-box-container-hover-enabled {
   width: 304px;
   height: 384px;
   background: $cb-white;
-  box-shadow: -4px -4px 0 0 $text-color;
+  box-shadow: -2px -2px 0 0 $text-color;
   border: 2px solid $text-color;
   border-radius: 0px 0px 10px;
+}
+
+.learning-group-box-container-hover-enabled {
+  &:hover {
+    transform: translate(1%, 1%);
+    background-color: $hero-color;
+    box-shadow: -6px -6px 0 0 $text-color, 0 10px 20px rgba(0,0,0,.12);
+    transition-duration: 0.3s;
+  }
+}
+
+.learning-group-box-container-locked {
+  text-align: center;
+  padding: 16px 16px 0 16px;
 }
 
 .learning-group-box-border {

--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -1,14 +1,11 @@
 <div class="path-show-page-container">
-
   <div class="path-progress-bar-container">
     <%= render 'shared/progress_bar',
       locals: {
       duration: @path_progress
     } %>
   </div>
-
   <div class="path-show-page-content-container">
-
     <div class="path-name-container">
       <h1><%= @path.name %></h1>
     </div>
@@ -27,9 +24,10 @@
     </div>
 
     <div class="container-right">
-      <%= render 'shared/learning_group_box' %>
+      <%= render 'shared/learning_group_box',
+      locals: {
+        first_step_completed: @step_data[@steps.first.id][:completion]
+      } %>
     </div>
-
   </div>
-
 </div>

--- a/app/views/shared/_learning_group_box.html.erb
+++ b/app/views/shared/_learning_group_box.html.erb
@@ -1,13 +1,23 @@
-  <div class="learning-group-box-container">
-    <div class="learning-group-box-text-container learning-group-box-border">
-      <h5 class="learninig-group-box-title">Let me help you out!</h5>
-      <p><strong>Learning Groups</strong> are a great way to improve your learning experience and
-      motivation.</p>
-      <p>Everyone gets stuck from time to time and <strong>a second pair of eyes</strong>
-      is one of the most important resources in a developer's life!</p>
-    </div>
-    <div class="btn-learning-group-box-container">
-      <p class="btn-card-sm text-center btn-learning-group-box">Join Learning Group</p>
-    </div>
-  </div>
+  <div class="learning-group-box-container<%= "-hover-enabled" if locals[:first_step_completed] %>" >
+    <% if locals[:first_step_completed] %>
+      <div class="learning-group-box-container-unlocked">
+        <%= link_to path_path(@path), class: 'join-learning-group-link-wrapper' do %>
+          <div class="learning-group-box-text-container learning-group-box-border">
+            <h5 class="learninig-group-box-title">Let me help you out!</h5>
+            <p><strong>Learning Groups</strong> are a great way to improve your learning experience and
+            motivation.</p>
+            <p>Everyone gets stuck from time to time and <strong>a second pair of eyes</strong>
+            is one of the most important resources in a developer's life!</p>
+          </div>
 
+          <div class="btn-learning-group-box-container">
+            <p class="btn-card-sm text-center btn-learning-group-box">Join Learning Group</p>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="learning-group-box-container-locked">
+        <p>Unlock Learning Groups by completing the first step of this path.</p>
+      </div>
+    <% end %>
+  </div>


### PR DESCRIPTION
when the first step of the path hasn't been completed yet, the user can't join a learning group
![learning_group_btn_disabled](https://user-images.githubusercontent.com/60707819/109721426-9e46db80-7bab-11eb-8850-6671c081067a.gif)

once the user has finished the first step of the path, he*she can join a learning group (link leading nowhere yet). Reminder: We will need a mechanism such that if a user clicks on 'mark as done' for the first step, the page will reload or something like that
![join_learning_group](https://user-images.githubusercontent.com/60707819/109721543-cafaf300-7bab-11eb-94ac-13fc62283736.gif)
