### PR TITLE
adding home page last fixing

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -65,8 +65,8 @@
   border-radius: 50px;
   width: 270px;
   height: 69px;
-  margin-top: 40px;
-  margin-left: 270px;
+  margin-top: 26px;
+  margin-left: 278px;
 }
 
 .card-start-learning .btn {
@@ -88,11 +88,11 @@
 }
 
 .btn-account {
-  color: #6C63FF;
+  color: $text-color;
   font-family: Roboto;
   padding-left: 40px;
   padding-top: 20px;
-  margin-left: 270px;
+  margin-left: 288px;
 }
 
 .btn-account:hover {
@@ -150,4 +150,11 @@
   margin-top: 60px;
   margin-bottom: 0;
   text-align: center;
+}
+
+.img-featuring {
+  margin-left: -191px;
+  margin-bottom: 80px;
+  margin-top: 40px;
+
 }

--- a/app/assets/stylesheets/components/_carousel.scss
+++ b/app/assets/stylesheets/components/_carousel.scss
@@ -1,0 +1,5 @@
+
+.carousel {
+  overflow-y: hidden;
+}
+

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -37,11 +37,17 @@
     </div>
     <div class="column">
     <div class="card-about">
-      <i class="fa fa-trophy purple home" aria-hidden="true"></i>
+      <i class="fa fa-trophy home" style="color: #FE0760;" aria-hidden="true"></i>
       <h4>Show your achievements across different learning platfroms</h4>
       <p>Want to show off your progress on Codewars, Codecademy and so on? No worries, connect your various accounts to CLP.</p>
     </div>
     </div>
+    <div class="img-featuring ">
+      <img src="https://res.cloudinary.com/dqopwdgta/image/upload/v1615470580/Home/platform_featuring_h93lcj.svg" alt="Featured learning platforms">
+    </div>
+
+
+
   </div>
 
 

--- a/app/views/shared/_carousel.html.erb
+++ b/app/views/shared/_carousel.html.erb
@@ -1,19 +1,19 @@
 <div id="carouselExampleSlidesOnly" class="carousel slide" data-ride="carousel">
   <div class="carousel-inner">
     <div class="carousel-item active">
-      <img class="d-block w-100" src="https://res.cloudinary.com/dqopwdgta/image/upload/v1615289999/Index/image_carousel/1_wpqzrq.svg" alt="First slide">
+      <img class="d-block w-100" src="https://res.cloudinary.com/dqopwdgta/image/upload/c_scale,h_450/v1615469671/Index/image_carousel/1_ifs8qr.svg" alt="First slide">
     </div>
     <div class="carousel-item">
-      <img class="d-block w-100" src="https://res.cloudinary.com/dqopwdgta/image/upload/v1615289999/Index/image_carousel/2_zfcbbz.svg" alt="Second slide">
+      <img class="d-block w-100" src="https://res.cloudinary.com/dqopwdgta/image/upload/c_scale,h_450/v1615469671/Index/image_carousel/2_zpls7w.svg" alt="Second slide">
     </div>
     <div class="carousel-item">
-      <img class="d-block w-100" src="https://res.cloudinary.com/dqopwdgta/image/upload/v1615289999/Index/image_carousel/3_kr1ajk.svg" alt="Third slide">
+      <img class="d-block w-100" src="https://res.cloudinary.com/dqopwdgta/image/upload/c_scale,h_450/v1615469671/Index/image_carousel/3_zmnoqh.svg" alt="Third slide">
     </div>
     <div class="carousel-item">
-      <img class="d-block w-100" src="https://res.cloudinary.com/dqopwdgta/image/upload/v1615289999/Index/image_carousel/4_krblsd.svg" alt="Fourth slide">
+      <img class="d-block w-100" src="https://res.cloudinary.com/dqopwdgta/image/upload/c_scale,h_450/v1615469671/Index/image_carousel/4_pa8ujo.svg" alt="Fourth slide">
     </div>
     <div class="carousel-item">
-      <img class="d-block w-100" src="https://res.cloudinary.com/dqopwdgta/image/upload/v1615289999/Index/image_carousel/5_umfiob.svg" alt="Fifth slide">
+      <img class="d-block w-100" src="https://res.cloudinary.com/dqopwdgta/image/upload/c_scale,h_450/v1615469671/Index/image_carousel/5_tamtzk.svg" alt="Fifth slide">
     </div>
   </div>
 </div>


### PR DESCRIPTION
- **Carousel**: resizes all images. For some reasons some of them had some .0002 extra pixels. Now they are all the same. Uploaded in wloudinary and slightly reduces the size in home page. Added class “carousel” with overflow-y: hidden. In my screen it works. Let’s see in other’s screen. 
- Modified colors of the purple cup. 
- Better alignment of button “start learning” 
- Added stripe “featured platforms” 

![Screenshot 2021-03-11 at 15 14 04](https://user-images.githubusercontent.com/5146740/110800412-70812700-827c-11eb-9f18-d136bd245883.png)
