### PR TITLE
external resource icons on step cards

### DIFF
--- a/app/views/shared/_step_card.html.erb
+++ b/app/views/shared/_step_card.html.erb
@@ -14,7 +14,7 @@
         <h5><%= locals[:step].title %></h5>
         <div class="step-card-external-source-icon-container">
           <% source = locals[:step].external_source_icon %>
-          <%#=  image_tag source[:path_to_source_icon], alt: source[:source_icon_alt], class: 'step-card-external-source-icon' %>
+          <%=  image_tag source[:path_to_source_icon], alt: source[:source_icon_alt], class: 'step-card-external-source-icon' %>
         </div>
       </div>
 


### PR DESCRIPTION
apparently someone accidently commented out the image tag for the icons. Now they're back for good
![image](https://user-images.githubusercontent.com/60707819/110824571-7a625480-8293-11eb-89f6-89b2426c5404.png)
