### PR TITLE
button on accordion (step card)

### DIFF
--- a/app/assets/stylesheets/components/_btn_accordion.scss
+++ b/app/assets/stylesheets/components/_btn_accordion.scss
@@ -14,6 +14,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
+  &:hover {
+    text-decoration: none;
+    opacity: 0.85;
+    color: white;
+  }
 }
 
 .btn-accordion-text {

--- a/app/assets/stylesheets/components/_step_card.scss
+++ b/app/assets/stylesheets/components/_step_card.scss
@@ -65,9 +65,7 @@
 .step-card-expanded-part {
   display: none;
   background-color: $cb-white;
-  padding-left: 140px;
-  padding-right: 36px;
-  padding-top: 36px;
+  padding: 36px 36px 36px 140px;
   border: 2px solid $text-color;
 }
 

--- a/app/assets/stylesheets/pages/_layout.scss
+++ b/app/assets/stylesheets/pages/_layout.scss
@@ -21,6 +21,7 @@
 
 .path-show-page-middle-container {
   width: 1120px;
+  margin-bottom: 100px;
 }
 
 .container-right {

--- a/app/views/shared/_btn_accordion.html.erb
+++ b/app/views/shared/_btn_accordion.html.erb
@@ -1,4 +1,4 @@
-<a href=<%= locals[:url] %>, class="btn-accordion-link-wrapper", target="_blank">
+<a href=<%= locals[:url] %>, class="btn-accordion-link-wrapper">
   <div class="btn-accordion">
     <div class="btn-accordion-text">
       <% if locals[:completed] %>

--- a/app/views/shared/_btn_accordion.html.erb
+++ b/app/views/shared/_btn_accordion.html.erb
@@ -1,4 +1,4 @@
-<a href=<%= locals[:url] %>, class="btn-accordion-link-wrapper">
+<a href=<%= locals[:url] %>, class="btn-accordion-link-wrapper", target="_blank">
   <div class="btn-accordion">
     <div class="btn-accordion-text">
       <% if locals[:completed] %>

--- a/app/views/shared/_step_card.html.erb
+++ b/app/views/shared/_step_card.html.erb
@@ -25,11 +25,6 @@
       <% end %>
     </div>
 
-<!--     <div class="step-card-external-source-icon-container">
-      <%# source = locals[:step].external_source_icon %>
-      <%#= image_tag source[:path_to_source_icon], alt: source[:source_icon_alt], class: 'step-card-external-source-icon' %>
-    </div> -->
-
     <div class="step-card-expand-icon <%= 'step-card-expand-icon-completed' if locals[:completed] %>">
       <i class="fas fa-angle-down"></i>
     </div>
@@ -52,27 +47,20 @@
 
     <div class="btn-accordion-container">
       <div>
-            <%= render 'shared/btn_accordion',
-      locals: {
-        completed: locals[:completed],
-        url: locals[:step].url
-      } %>
-
+        <%= render 'shared/btn_accordion',
+          locals: {
+            completed: locals[:completed],
+            url: locals[:step].url
+          }
+        %>
       </div>
+
       <div style="margin-top: 20px;">
         <%#= link_to "Done", step_progress_path(locals[:step_progress_id]), method: :patch, class: 'btn-accordion btn-accordion-text' %>
         <%#= link_to "Click Here", page_path, :id => 'login', "data-toggle" => "modal", 'data-target' => '#loginModal' %>
-        <%= link_to "Done", step_progress_path(locals[:step_progress_id]), class: 'btn-accordion btn-accordion-text', data: {toggle: "modal", target: "#step-modal"} %>
-
-
+        <%= link_to "Done", step_progress_path(locals[:step_progress_id]), class: 'btn-accordion btn-accordion-text', data: {toggle: "modal", target: "#step-modal"} unless locals[:completed] %>
         <!-- Here I remove the mathod: :patch and just trigger the modal data toggle -->
       </div>
     </div>
-
-
-
-
-
   </div>
-
 </div>


### PR DESCRIPTION
### Path Show Page
- add space between Done Button and bottom of card
![image](https://user-images.githubusercontent.com/60707819/110921196-94954480-831e-11eb-8b70-b2464381ec82.png)

- adjust the hover effect of Done button (so it 's consistent with the "Start" button)
![btn_accordion_hover](https://user-images.githubusercontent.com/60707819/110921312-b393d680-831e-11eb-8f09-6d3cfbb56682.gif)

- Done button only displayed when step hasn't been marked as done yet
![image](https://user-images.githubusercontent.com/60707819/110921400-cdcdb480-831e-11eb-858d-09844b55e331.png)

- Margin bottom on last step card
![image](https://user-images.githubusercontent.com/60707819/110922342-dd013200-831f-11eb-9cde-17498e4bcfd5.png)
