### PR TITLE
Chat layout

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -107,3 +107,34 @@
   background-color: transparent;
   @extend p;
 }
+
+#toggle-chat-button {
+  width: 50%;
+  &:hover {
+    opacity: 0.85;
+  }
+}
+
+#toggle-chat-button button {
+  width: 100%;
+  font-size: 20px;
+  font-weight: bold;
+  padding: 0.3em 0.6em;
+  border-radius: 50px;
+  transition: 0.2s ease;
+}
+
+#toggle-chat-button #btn-ask {
+    border: none;
+    background-color: $text-color;
+    color: white;
+  i {
+    margin-left: 8px;
+  }
+}
+
+#toggle-chat-button #btn-hide {
+  background-color: white;
+  border: 2px solid $text-color;
+  color: $text-color;
+}

--- a/app/assets/stylesheets/components/_chatroom.scss
+++ b/app/assets/stylesheets/components/_chatroom.scss
@@ -1,10 +1,14 @@
 .invisible {
   display: none;
-
 }
 
-.visible {
-  display: inline;
+.chatroom-container {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 90%;
+  padding: 1rem;
 }
 
 .chatroom {
@@ -23,17 +27,51 @@
 }
 
 #messages {
+  border-radius: 12px;
+  background: rgba($text-color, 0.1);
+  width: 100%;
   padding: 0 1rem;
   padding-top: 1rem;
-  overflow: scroll;
-  max-height: calc(100vh - 66px - 65px - 71px);
+  overflow-y: hidden;
+  // max-height: calc(100vh - 66px - 65px - 71px);
+  max-height: 46vh;
+
+  &:hover {
+    overflow-y: auto;
+  }
 }
 
 #new_message {
-  padding: 1rem;
-  border-top: 1px solid $gray-200;
+  padding: 1rem 0;
+  // border-top: 2px solid $gray-200;
+
+  #message_content {
+    border: none;
+    background: transparent;
+    padding: 0;
+
+    &:focus {
+      border: none;
+      box-shadow: none;
+    }
+  }
 
   .form-group {
     margin-bottom: 0;
   }
+
+  .send-message {
+    border: none;
+    background-color: inherit;
+    box-shadow: none;
+    color: $text-color;
+    margin-left: 6px;
+  }
+}
+
+.message-input-and-submit-container {
+  display: flex;
+  border-radius: 50px;
+  border: 2px solid $text-color;
+  padding: 0 0.8rem;
 }

--- a/app/assets/stylesheets/components/_message.scss
+++ b/app/assets/stylesheets/components/_message.scss
@@ -5,6 +5,6 @@
   }
 
   small {
-    color: $gray-500;
+    // color: $gray-500;
   }
 }

--- a/app/assets/stylesheets/pages/_layout.scss
+++ b/app/assets/stylesheets/pages/_layout.scss
@@ -26,9 +26,11 @@
 .container-right {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  align-items: center;
   width: 420px;
   padding-top: 38px;
+  height: 80vh;
+  position: sticky;
+  top: 0;
+  right: 0;
 }
-
-

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,7 +12,8 @@ class MessagesController < ApplicationController
         render_to_string(partial: "message", locals: { message: @message })
       )
 
-      redirect_to path_path(@path, anchor: "message-#{@message.id}")
+      # redirect_to path_path(@path, anchor: "message-#{@message.id}")
+      redirect_to path_path(@path)
     else
       render 'path/show'
     end

--- a/app/javascript/custom/toggle_chat.js
+++ b/app/javascript/custom/toggle_chat.js
@@ -1,13 +1,16 @@
 const initToggleChatEventListener = () => {
-  const learningGroupButton = document.getElementById('toggle-chat-button');
+  const showHideChatButton = document.getElementById('toggle-chat-button');
   const chat = document.getElementById('path_show_chatroom');
+  const showChatButton = document.getElementById('btn-ask');
+  const hideChatButton = document.getElementById('btn-hide');
 
-  if (learningGroupButton && chat) {
-    learningGroupButton.addEventListener('click', (event) => {
+  if (showHideChatButton && chat) {
+    showHideChatButton.addEventListener('click', (event) => {
       console.log('event fired!');
       event.preventDefault();
-      chat.classList.toggle('visible');
       chat.classList.toggle('invisible');
+      showChatButton.classList.toggle('invisible');
+      hideChatButton.classList.toggle('invisible');
     });
   }
 }

--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -29,28 +29,27 @@
     </div>
 
     <div class="container-right">
-      <div>
       <%= render 'shared/learning_group_box',
       locals: {
         first_step_completed: @step_data[@steps.first.id][:completion]
       } %>
-     </div>
-     <div id="path_show_chatroom" class="chatroom-container invisible">
-       <h5>#<%= @chatroom.name %></h5>
+     <div id="path_show_chatroom" class="chatroom-container visible">
+       <h4>#<%= @chatroom.name %></h4>
          <div id="messages" data-chatroom-id="<%= @chatroom.id %>">
-            <% @chatroom.messages.each do |message| %>
+            <% @chatroom.messages.reverse[0..2].each do |message| %>
             <%= render 'messages/message', message: message %>
             <% end %>
           </div>
 
         <%= simple_form_for [ @path, @chatroom, @message ], remote: true do |f| %>
-        <%= f.input :content, label: false, placeholder: "Message ##{@chatroom.name}" %>
-        <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-        <%= f.submit "send message" %>
+          <div class="message-input-and-submit-container">
+            <%= f.input :content, label: false, placeholder: "ask a question" %>
+            <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+            <%= button_tag type: 'submit', class: "send-message" do %>
+              <i class="fas fa-paper-plane"></i>
+            <% end %>
+          </div>
         <% end %>
     </div>
   </div>
-
-
-
 </div>

--- a/app/views/shared/_learning_group_box.html.erb
+++ b/app/views/shared/_learning_group_box.html.erb
@@ -1,7 +1,7 @@
-  <div id="toggle-chat-button" class="learning-group-box-container<%= "-hover-enabled" if locals[:first_step_completed] %>" >
-    <% if locals[:first_step_completed] %>
+<!--   <div id="toggle-chat-button" class="learning-group-box-container<%#= "-hover-enabled" if locals[:first_step_completed] %>" >
+    <%# if locals[:first_step_completed] %>
       <div class="learning-group-box-container-unlocked">
-        <%= link_to path_path(@path), class: 'join-learning-group-link-wrapper' do %>
+        <%#= link_to path_path(@path), class: 'join-learning-group-link-wrapper' do %>
           <div class="learning-group-box-text-container learning-group-box-border">
             <h5 class="learninig-group-box-title">Let me help you out!</h5>
             <p><strong>Coding buddies</strong> are a great way to improve your learning experience and
@@ -13,11 +13,16 @@
           <div class="btn-learning-group-box-container">
             <p class="btn-card-sm text-center btn-learning-group-box">Ask for help</p>
           </div>
-        <% end %>
+        <%# end %>
       </div>
-    <% else %>
+    <%# else %>
       <div class="learning-group-box-container-locked">
         <p>Unlock Learning Groups by completing the first step of this path.</p>
       </div>
-    <% end %>
+    <%# end %>
+  </div> -->
+
+  <div id="toggle-chat-button">
+    <button id="btn-ask" class="invisible">Ask a Question <i class="far fa-comment-alt"></i></button>
+    <button id="btn-hide">Hide Chat</button>
   </div>


### PR DESCRIPTION
- reduced "learning group box" to a simple button
- new messages get added at the top
- position of chatbox is sticky
- chat is enabled by default with the option to hide it (couldn't figure out another way since sending a message reloads the page and then you want the chat to be displayed after you've just sent a message)
- chat only shows the last 3 messages
- chat scrollbar only activated on y-axis on hover and only if needed
![chat_layout](https://user-images.githubusercontent.com/60707819/110946329-04b3c280-833f-11eb-94db-c25a5892e043.gif)

