### PR TITLE
Fix icons

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,6 @@
     <%= csp_meta_tag %>
 
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <script src="https://code.iconify.design/1/1.0.7/iconify.min.js"></script>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <!-- <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css"> -->
 
@@ -40,5 +39,6 @@
       <%= render 'shared/flashes' %>
       <div class="footer-container"><%= render "shared/footer" %></div>
     </div>
+    <script src="https://code.iconify.design/1/1.0.7/iconify.min.js"></script>
   </body>
 </html>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -30,7 +30,8 @@ OF THE CARDS CAN HAPPEN BEFORE THAT DECISION. -->
         <div class="w-third mr-60 profile-card-top">
           <div class="profile-card-content">
             <h6>Frontend Developer Path</h6>
-            <span class="iconify profile-cup completed-yellow" data-icon="si-glyph:champion-cup" data-inline="false" style="font-size: 100px;"></span>
+            <!-- <span class="iconify profile-cup completed-yellow" data-icon="si-glyph:champion-cup" data-inline="false" style="font-size: 100px;"></span> -->
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1.07em" height="1em" style="font-size: 100px; transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 17 16" class="iconify profile-cup completed-yellow" data-icon="si-glyph:champion-cup" data-inline="false"><path d="M11.969 1H3.082v1.031h-3.09v4.836c0 1.869 2.086 3.407 4.133 3.567c.672.72 1.854 1.243 2.906 1.466v1.264c-1.006.309-2.803 1.035-2.906 1.826h6.904c-.104-.791-2.084-1.518-3.092-1.826V11.9c1.056-.223 2.291-.746 2.964-1.466c2.046-.16 4.04-1.698 4.04-3.567V2.031h-2.972V1zM.941 2.947H3.01v4.166c0 .822.212 1.604.585 2.308C2.047 8.928.941 7.658.941 6.172V2.947zm8.104 5.081l-1.544-.851l-1.546.851l.295-1.8L5 4.954l1.727-.263l.774-1.636l.772 1.636L10 4.954L8.75 6.228l.295 1.8zm2.295 1.526c.375-.736.59-1.55.59-2.411V2.974h2.074V6.16c0 1.553-1.111 2.879-2.664 3.394z" fill="currentColor" fill-rule="evenodd"></path></svg>
             <p style="padding-top: 20px; padding-bottom: 30px;"><i class="fas fa-check-circle step-card-completed-icon"></i> Completed</p>
           </div>
             <div class="profile-card-see-btn pt-1">
@@ -43,7 +44,8 @@ OF THE CARDS CAN HAPPEN BEFORE THAT DECISION. -->
 <!-- THE CUP BECOMES YELLOW BY ADDING THE completed-yellow CLASS TO IT -->
             <h6>Full Stack Developer Path</h6>
             <div class="profile-trophy-percentage">
-            <span class="iconify profile-cup" data-icon="si-glyph:champion-cup" data-inline="false" style="font-size: 100px;"></span>
+            <!-- <span class="iconify profile-cup" data-icon="si-glyph:champion-cup" data-inline="false" style="font-size: 100px;"></span> -->
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1.07em" height="1em" style="font-size: 100px; transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 17 16" class="iconify profile-cup" data-icon="si-glyph:champion-cup" data-inline="false"><path d="M11.969 1H3.082v1.031h-3.09v4.836c0 1.869 2.086 3.407 4.133 3.567c.672.72 1.854 1.243 2.906 1.466v1.264c-1.006.309-2.803 1.035-2.906 1.826h6.904c-.104-.791-2.084-1.518-3.092-1.826V11.9c1.056-.223 2.291-.746 2.964-1.466c2.046-.16 4.04-1.698 4.04-3.567V2.031h-2.972V1zM.941 2.947H3.01v4.166c0 .822.212 1.604.585 2.308C2.047 8.928.941 7.658.941 6.172V2.947zm8.104 5.081l-1.544-.851l-1.546.851l.295-1.8L5 4.954l1.727-.263l.774-1.636l.772 1.636L10 4.954L8.75 6.228l.295 1.8zm2.295 1.526c.375-.736.59-1.55.59-2.411V2.974h2.074V6.16c0 1.553-1.111 2.879-2.664 3.394z" fill="currentColor" fill-rule="evenodd"></path></svg>
             <h5>45%</h5>
             </div>
             <!-- <p><i class="fas fa-check-circle step-card-completed-icon ml-32"></i> Completed</p> -->

--- a/app/views/shared/_big_card.html.erb
+++ b/app/views/shared/_big_card.html.erb
@@ -1,16 +1,20 @@
   <!-- Cup - title - description -->
   <% path_name  %>
   <% if path_name == "Full Stack Developer" %>
-    <span class="iconify"  data-icon="si-glyph:champion-cup" data-inline="false" style="font-size: 150px; color: #F3C72A;"></span>
+    <!-- <span class="iconify"  data-icon="si-glyph:champion-cup" data-inline="false" style="font-size: 150px; color: #F3C72A;"></span> -->
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1.07em" height="1em" style="font-size: 150px; color: rgb(243, 199, 42); transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 17 16" class="iconify" data-icon="si-glyph:champion-cup" data-inline="false"><path d="M11.969 1H3.082v1.031h-3.09v4.836c0 1.869 2.086 3.407 4.133 3.567c.672.72 1.854 1.243 2.906 1.466v1.264c-1.006.309-2.803 1.035-2.906 1.826h6.904c-.104-.791-2.084-1.518-3.092-1.826V11.9c1.056-.223 2.291-.746 2.964-1.466c2.046-.16 4.04-1.698 4.04-3.567V2.031h-2.972V1zM.941 2.947H3.01v4.166c0 .822.212 1.604.585 2.308C2.047 8.928.941 7.658.941 6.172V2.947zm8.104 5.081l-1.544-.851l-1.546.851l.295-1.8L5 4.954l1.727-.263l.774-1.636l.772 1.636L10 4.954L8.75 6.228l.295 1.8zm2.295 1.526c.375-.736.59-1.55.59-2.411V2.974h2.074V6.16c0 1.553-1.111 2.879-2.664 3.394z" fill="currentColor" fill-rule="evenodd"></path></svg>
     <h5 class="mt-4">The Full Stack Developer Path</h5>
   <% elsif path_name == "Frontend Developer" %>
-    <span class="iconify"  data-icon="si-glyph:champion-cup" data-inline="false" style="font-size: 150px; color: #997029;"></span>
+    <!-- <span class="iconify"  data-icon="si-glyph:champion-cup" data-inline="false" style="font-size: 150px; color: #997029;"></span> -->
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1.07em" height="1em" style="font-size: 150px; color: rgb(153, 112, 41); transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 17 16" class="iconify" data-icon="si-glyph:champion-cup" data-inline="false"><path d="M11.969 1H3.082v1.031h-3.09v4.836c0 1.869 2.086 3.407 4.133 3.567c.672.72 1.854 1.243 2.906 1.466v1.264c-1.006.309-2.803 1.035-2.906 1.826h6.904c-.104-.791-2.084-1.518-3.092-1.826V11.9c1.056-.223 2.291-.746 2.964-1.466c2.046-.16 4.04-1.698 4.04-3.567V2.031h-2.972V1zM.941 2.947H3.01v4.166c0 .822.212 1.604.585 2.308C2.047 8.928.941 7.658.941 6.172V2.947zm8.104 5.081l-1.544-.851l-1.546.851l.295-1.8L5 4.954l1.727-.263l.774-1.636l.772 1.636L10 4.954L8.75 6.228l.295 1.8zm2.295 1.526c.375-.736.59-1.55.59-2.411V2.974h2.074V6.16c0 1.553-1.111 2.879-2.664 3.394z" fill="currentColor" fill-rule="evenodd"></path></svg>
     <h5 class="mt-4">The Frontend Developer Path</h5>
   <% elsif path_name == "Data Analyst" %>
-    <span class="iconify"  data-icon="si-glyph:champion-cup" data-inline="false" style="font-size: 150px; color: #FE0760;"></span>
+    <!-- <span class="iconify"  data-icon="si-glyph:champion-cup" data-inline="false" style="font-size: 150px; color: #FE0760;"></span> -->
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1.07em" height="1em" style="font-size: 150px; color: rgb(254, 7, 96); transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 17 16" class="iconify" data-icon="si-glyph:champion-cup" data-inline="false"><path d="M11.969 1H3.082v1.031h-3.09v4.836c0 1.869 2.086 3.407 4.133 3.567c.672.72 1.854 1.243 2.906 1.466v1.264c-1.006.309-2.803 1.035-2.906 1.826h6.904c-.104-.791-2.084-1.518-3.092-1.826V11.9c1.056-.223 2.291-.746 2.964-1.466c2.046-.16 4.04-1.698 4.04-3.567V2.031h-2.972V1zM.941 2.947H3.01v4.166c0 .822.212 1.604.585 2.308C2.047 8.928.941 7.658.941 6.172V2.947zm8.104 5.081l-1.544-.851l-1.546.851l.295-1.8L5 4.954l1.727-.263l.774-1.636l.772 1.636L10 4.954L8.75 6.228l.295 1.8zm2.295 1.526c.375-.736.59-1.55.59-2.411V2.974h2.074V6.16c0 1.553-1.111 2.879-2.664 3.394z" fill="currentColor" fill-rule="evenodd"></path></svg>
     <h5 class="mt-4">The Data Analyst Path</h5>
   <% else %>
-    <span class="iconify" data-icon="si-glyph:champion-cup"  data-inline="false" style="font-size: 150px; color: #6C63FF;"></span>
+    <!-- <span class="iconify" data-icon="si-glyph:champion-cup"  data-inline="false" style="font-size: 150px; color: #6C63FF;"></span> -->
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1.07em" height="1em" style="font-size: 150px; color: rgb(108, 99, 255); transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 17 16" class="iconify" data-icon="si-glyph:champion-cup" data-inline="false"><path d="M11.969 1H3.082v1.031h-3.09v4.836c0 1.869 2.086 3.407 4.133 3.567c.672.72 1.854 1.243 2.906 1.466v1.264c-1.006.309-2.803 1.035-2.906 1.826h6.904c-.104-.791-2.084-1.518-3.092-1.826V11.9c1.056-.223 2.291-.746 2.964-1.466c2.046-.16 4.04-1.698 4.04-3.567V2.031h-2.972V1zM.941 2.947H3.01v4.166c0 .822.212 1.604.585 2.308C2.047 8.928.941 7.658.941 6.172V2.947zm8.104 5.081l-1.544-.851l-1.546.851l.295-1.8L5 4.954l1.727-.263l.774-1.636l.772 1.636L10 4.954L8.75 6.228l.295 1.8zm2.295 1.526c.375-.736.59-1.55.59-2.411V2.974h2.074V6.16c0 1.553-1.111 2.879-2.664 3.394z" fill="currentColor" fill-rule="evenodd"></path></svg>
     <h5 class="mt-4">The iOs Developer Path</h5>
   <% end %>
   <br>
@@ -104,8 +108,3 @@
       </div>
     </div>
   </p>
-
-
-
-
-

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -4,7 +4,8 @@
     <%= link_to "#", class: "navbar-brand" do %>
     <%# INCLUDE THE ICO THING HERE %>
       <%# image_tag "https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/logo.png" %>
-      <span class="iconify logo" data-inline="false" data-icon="ph:path-bold" style="font-size: 35px; color: #003366;"></span>
+      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1em" height="1em" style="font-size: 35px; color: rgb(0, 51, 102); transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 256 256" class="iconify logo" data-inline="false" data-icon="ph:path-bold"><path d="M200 164a36.057 36.057 0 0 0-33.936 24H72a28 28 0 0 1 0-56h96a44 44 0 0 0 0-88H72a12 12 0 0 0 0 24h96a20 20 0 0 1 0 40H72a52 52 0 0 0 0 104h94.064A35.998 35.998 0 1 0 200 164zm0 48a12 12 0 1 1 12-12a12.013 12.013 0 0 1-12 12z" fill="currentColor"></path></svg>
+      <!-- <span class="iconify logo" data-inline="false" data-icon="ph:path-bold" style="font-size: 35px; color: #003366;"></span> -->
     <% end %>
     <%= link_to "ALL PATHS", paths_path, class: "navbar-h3"  %>
   </div>

--- a/app/views/shared/_progress_bar.html.erb
+++ b/app/views/shared/_progress_bar.html.erb
@@ -7,7 +7,8 @@
     aria-valuemax="100"><p><%= "#{locals[:duration]}%" %></p></div>
   </div>
   <!-- <i class="fas fa-trophy" ></i> -->
-  <span class="iconify" data-icon="si-glyph:champion-cup" data-inline="false"></span>
+  <!-- <span class="iconify" data-icon="si-glyph:champion-cup" data-inline="false"></span> -->
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1.07em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 17 16" class="iconify" data-icon="si-glyph:champion-cup" data-inline="false" style="transform: rotate(360deg);"><path d="M11.969 1H3.082v1.031h-3.09v4.836c0 1.869 2.086 3.407 4.133 3.567c.672.72 1.854 1.243 2.906 1.466v1.264c-1.006.309-2.803 1.035-2.906 1.826h6.904c-.104-.791-2.084-1.518-3.092-1.826V11.9c1.056-.223 2.291-.746 2.964-1.466c2.046-.16 4.04-1.698 4.04-3.567V2.031h-2.972V1zM.941 2.947H3.01v4.166c0 .822.212 1.604.585 2.308C2.047 8.928.941 7.658.941 6.172V2.947zm8.104 5.081l-1.544-.851l-1.546.851l.295-1.8L5 4.954l1.727-.263l.774-1.636l.772 1.636L10 4.954L8.75 6.228l.295 1.8zm2.295 1.526c.375-.736.59-1.55.59-2.411V2.974h2.074V6.16c0 1.553-1.111 2.879-2.664 3.394z" fill="currentColor" fill-rule="evenodd"></path></svg>
 </div>
 
 <%# hourly_sum = 0

--- a/app/views/shared/_step_card.html.erb
+++ b/app/views/shared/_step_card.html.erb
@@ -1,12 +1,11 @@
-<script src="https://code.iconify.design/1/1.0.6/iconify.min.js"></script>
-
 <div class="step-card-container">
 
   <div class="step-card-closed-part">
 
     <div class="step-card-logo-container">
-      <span class="iconify logo <%= 'logo-completed' if locals[:completed] %>"
-      data-inline="false" data-icon="ph:path-bold"></span>
+      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 256 256" class="iconify logo <%= 'logo-completed' if locals[:completed] %>" data-inline="false" data-icon="ph:path-bold" style="transform: rotate(360deg);"><path d="M200 164a36.057 36.057 0 0 0-33.936 24H72a28 28 0 0 1 0-56h96a44 44 0 0 0 0-88H72a12 12 0 0 0 0 24h96a20 20 0 0 1 0 40H72a52 52 0 0 0 0 104h94.064A35.998 35.998 0 1 0 200 164zm0 48a12 12 0 1 1 12-12a12.013 12.013 0 0 1-12 12z" fill="currentColor"></path></svg>
+      <!-- <span class="iconify logo <%#= 'logo-completed' if locals[:completed] %>" -->
+      <!-- data-inline="false" data-icon="ph:path-bold"></span> -->
     </div>
 
     <div class="step-card-text">


### PR DESCRIPTION
I implemented a quick and dirty fix for the icons to properly display. 
**We'll see if this works on heroku.** If not, it's super easy to undo.

### what the q&d fix is
Iconify searches for `span`s with the class "iconify" and replaces them with the HTML code for the SVGs. This is done by JS calling an API which returns the matching HTML based on the `data-icon` attribute.
I inspected the page in the browser and copied the API response (the HTML code for the SVG) and replaced all iconify-`span`s manually.
I *assume* that this is deprecated, mainly due to longer loading times since now the browser renders the SVGs in the order they appear in the HTML and not at the end after all other elements have already been loaded. This is a guess. As you can see below it works fine for me.

![icons_as_svg](https://user-images.githubusercontent.com/60707819/110973912-2bcdbc80-835e-11eb-84b2-9fe959213593.gif)