### PR TITLE
github profile caused error if it was nil

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -58,7 +58,7 @@ OF THE CARDS CAN HAPPEN BEFORE THAT DECISION. -->
 <!-- These are divs for user's external profiles -->
 
       <h2 style="margin-top: 36px; margin-bottom: 46px;">YOUR EXTERNAL PROFILES</h2>
-      <% if @user.codewars_profile %>
+      <% if @user.codewars_profile && @user.github_profile %>
         <div class="d-flex justify-content-between">
           <div class="w-47 profile-card" style="background-color: #003366">
             <div class="profile-card">


### PR DESCRIPTION
the profile page only checked if the codewars_profile existed and based on that displayed either both or none external profile. I somehow managed to have only the codewars_profile which was resulting in a Nilclass-error on the profile page so I fixed the if-statement