### PR TITLE
add external profiles

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -3,7 +3,6 @@
   padding: 10px 42px;
   color: $cb-white;
   margin-bottom: 0 !important;
-
 }
 
 .btn-btn-card-sm.custom {
@@ -68,7 +67,6 @@
      border: 3px solid $text-color;
  }
 
-
  .btn-modal {
   padding: 10px 42px;
   color: $cb-white;
@@ -98,14 +96,22 @@
   }
 
 .btn-edit-profile {
-  padding: 15px 32px;
-  border-radius: 4px;
-  border: 1px solid $text-color;
+  padding: .5em 1em;
+  font-weight: bold;
+  border: none;
   text-align: center;
   text-decoration: none;
   display: inline-block;
-  background-color: transparent;
+  background-color: $text-color;
+  color: white;
+  box-sizing: border-box;
+  width: 100%;
   @extend p;
+
+  &:hover {
+    text-decoration: none;
+    opacity: 0.85;
+  }
 }
 
 #toggle-chat-button {

--- a/app/assets/stylesheets/components/_profile_card.scss
+++ b/app/assets/stylesheets/components/_profile_card.scss
@@ -36,7 +36,6 @@
   bottom: 7px;
 }
 
-
 .profile-card {
   box-sizing: border-box;
   height: 75%;
@@ -95,7 +94,6 @@
   border: 2px solid $text-color;
 }
 
-
 .profile-section {
   width: 200px;
   font-weight: bolder;
@@ -134,3 +132,17 @@
   align-items: center;
  }
 
+.codewars_profile_user_name, .github_profile_user_name{
+  margin-bottom: .5rem;
+}
+
+#codewars_profile_user_name:focus, #github_profile_user_name:focus {
+  box-shadow: none;
+  border: 2px solid rgba($text-color, 0.5);
+}
+
+.external-profile-form-container {
+  width: 250px;
+  margin-right: 4rem;
+  margin-bottom: 2rem;
+}

--- a/app/controllers/codewars_profiles_controller.rb
+++ b/app/controllers/codewars_profiles_controller.rb
@@ -28,7 +28,8 @@ class CodewarsProfilesController < ApplicationController
     authorize @codewars_profile
 
     if @codewars_profile.save
-      redirect_to edit_profile_path(current_user.name)
+      # redirect_to edit_profile_path(current_user.name)
+      redirect_to user_profile_path(current_user.name)
       # render nothing: true // this did not work.
     else
       redirect_to user_profile_path(current_user.name)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,6 +2,8 @@ class ProfilesController < ApplicationController
   def show
     @user = User.find_by(name: params[:user_name])
     authorize @user
+    @codewars_profile = CodewarsProfile.new
+    @github_profile = GithubProfile.new
     # @codewars_profile = CodewarsProfile.new
   end
 
@@ -10,8 +12,8 @@ class ProfilesController < ApplicationController
   def edit
     @user = User.find_by(name: params[:user_name])
     authorize @user
-    @codewars_profile = CodewarsProfile.new
-    @github_profile = GithubProfile.new
+    # @codewars_profile = CodewarsProfile.new
+    # @github_profile = GithubProfile.new
   end
 
   # I am not implementing the update method yet, because there is no information

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -57,127 +57,154 @@ OF THE CARDS CAN HAPPEN BEFORE THAT DECISION. -->
 
 <!-- These are divs for user's external profiles -->
 
-      <h2 style="margin-top: 36px; margin-bottom: 46px;">YOUR EXTERNAL PROFILES</h2>
-      <% if @user.codewars_profile %>
+      <h2 style="margin-top: 36px; margin-bottom: 0.8em;">YOUR EXTERNAL PROFILES</h2>
+
+      <div class="add-external-profile-form-container d-flex flex-start">
+        <% if current_user.codewars_profile.nil? %>
+          <!-- <h2 style="margin-top: 46px; margin-bottom: 20px;">Please add your <span style="background-color: #A9DCDB">Codewars</span> username</h2> -->
+          <div class="external-profile-form-container">
+            <%= simple_form_for (@codewars_profile) do |f| %>
+              <%= f.input :user_name, label: false, placeholder: 'CodeWars username', input_html: { class: 'profile-input' } %>
+              <%= f.submit 'Add Codewars profile', class: 'btn-edit-profile' %>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% if current_user.github_profile.nil? %>
+          <div class="external-profile-form-container">
+            <%= simple_form_for (@github_profile) do |f| %>
+              <%= f.input :user_name, label: false, placeholder: 'GitHub username', input_html: { class: 'profile-input' } %>
+              <%= f.submit 'Add GitHub profile', class: 'btn-edit-profile' %>
+            <% end %>
+          </div>
+          <!-- <h2 style="margin-top: 46px; margin-bottom: 20px;">Please add your <span style="background-color: #A9DCDB">GitHub</span> username</h2> -->
+        <% end %>
+      </div>
+
+      <% if @user.codewars_profile || @user.github_profile %>
         <div class="d-flex justify-content-between">
-          <div class="w-47 profile-card" style="background-color: #003366">
-            <div class="profile-card">
-              <div class="profile-card-content codewars">
-                <div class="icon-profile">
-                  <span class="iconify" data-inline="false" data-icon="cib:codewars" style="font-size: 60px; color: #FE0760; padding-bottom: 15px;"></span>
-                  <h6 style="padding-bottom: 14px; padding-left: -20px;">Codewars Profile</h6>
-                </div>
-                <div class="profile-data d-flex" style="align-items: center;">
-                  <div class="profile-section">
-                    <p> <span class="iconify" data-inline="false" data-icon="si-glyph:champion-cup" style="font-size: 18px; color: #FE0760;"></span> HONORS</p>
+          <% if @user.codewars_profile %>
+            <div class="w-47 profile-card" style="background-color: #003366">
+              <div class="profile-card">
+                <div class="profile-card-content codewars">
+                  <div class="icon-profile">
+                    <span class="iconify" data-inline="false" data-icon="cib:codewars" style="font-size: 60px; color: #FE0760; padding-bottom: 15px;"></span>
+                    <h6 style="padding-bottom: 14px; padding-left: -20px;">Codewars Profile</h6>
                   </div>
-                  <div class="profile-score">
-                    <p><%= @user.codewars_profile.honor %></p>
+                  <div class="profile-data d-flex" style="align-items: center;">
+                    <div class="profile-section">
+                      <p> <span class="iconify" data-inline="false" data-icon="si-glyph:champion-cup" style="font-size: 18px; color: #FE0760;"></span> HONORS</p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.codewars_profile.honor %></p>
+                    </div>
                   </div>
-                </div>
-                <div class="profile-data d-flex">
-                  <div class="profile-section">
-                    <p><span class="iconify" data-inline="false" data-icon="si-glyph:champion-cup" style="font-size: 18px; color: #FE0760;"></span> OVERALL RANK</p>
+                  <div class="profile-data d-flex">
+                    <div class="profile-section">
+                      <p><span class="iconify" data-inline="false" data-icon="si-glyph:champion-cup" style="font-size: 18px; color: #FE0760;"></span> OVERALL RANK</p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.codewars_profile.overall_rank_name %></p>
+                    </div>
                   </div>
-                  <div class="profile-score">
-                    <p><%= @user.codewars_profile.overall_rank_name %></p>
+                  <div class="profile-data d-flex" style="align-items: center;">
+                    <div class="profile-section">
+                      <p> <span class="iconify" data-inline="false" data-icon="si-glyph:champion-cup" style="font-size: 18px; color: #FE0760;"></span> OVERALL SCORE</p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.codewars_profile.overall_score %></p>
+                    </div>
                   </div>
-                </div>
-                <div class="profile-data d-flex" style="align-items: center;">
-                  <div class="profile-section">
-                    <p> <span class="iconify" data-inline="false" data-icon="si-glyph:champion-cup" style="font-size: 18px; color: #FE0760;"></span> OVERALL SCORE</p>
+                  <div class="profile-data d-flex" style="align-items: center;">
+                    <div class="profile-section">
+                      <p>CHALLENGES AUTHORED </p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.codewars_profile.code_challenges_authored %></p>
+                    </div>
                   </div>
-                  <div class="profile-score">
-                    <p><%= @user.codewars_profile.overall_score %></p>
+                  <div class="profile-data d-flex" style="align-items: center;">
+                    <div class="profile-section">
+                      <p>CHALLENGES COMPLETED </p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.codewars_profile.code_challenges_completed %></p>
+                    </div>
                   </div>
-                </div>
-                <div class="profile-data d-flex" style="align-items: center;">
-                  <div class="profile-section">
-                    <p>CHALLENGES AUTHORED </p>
+                  <div class="profile-data d-flex" style="align-items: center;">
+                    <div class="profile-section">
+                      <p><%= @user.codewars_profile.first_language_name.upcase! %> </p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.codewars_profile.first_language_rank_name %> [<%= @user.codewars_profile.first_language_score %>]</p>
+                    </div>
                   </div>
-                  <div class="profile-score">
-                    <p><%= @user.codewars_profile.code_challenges_authored %></p>
+                  <% if @user.codewars_profile.second_language_name != 'None chosen' %>
+                  <div class="profile-data d-flex" style="align-items: center;">
+                    <div class="profile-section">
+                      <p><%= @user.codewars_profile.second_language_name.upcase! %> </p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.codewars_profile.second_language_rank_name %> [<%= @user.codewars_profile.second_language_score%>]</p>
+                    </div>
                   </div>
-                </div>
-                <div class="profile-data d-flex" style="align-items: center;">
-                  <div class="profile-section">
-                    <p>CHALLENGES COMPLETED </p>
-                  </div>
-                  <div class="profile-score">
-                    <p><%= @user.codewars_profile.code_challenges_completed %></p>
-                  </div>
-                </div>
-                <div class="profile-data d-flex" style="align-items: center;">
-                  <div class="profile-section">
-                    <p><%= @user.codewars_profile.first_language_name.upcase! %> </p>
-                  </div>
-                  <div class="profile-score">
-                    <p><%= @user.codewars_profile.first_language_rank_name %> [<%= @user.codewars_profile.first_language_score %>]</p>
-                  </div>
-                </div>
-                <% if @user.codewars_profile.second_language_name != 'None chosen' %>
-                <div class="profile-data d-flex" style="align-items: center;">
-                  <div class="profile-section">
-                    <p><%= @user.codewars_profile.second_language_name.upcase! %> </p>
-                  </div>
-                  <div class="profile-score">
-                    <p><%= @user.codewars_profile.second_language_rank_name %> [<%= @user.codewars_profile.second_language_score%>]</p>
-                  </div>
-                </div>
-                <% end %>
-              </div>
-            </div>
-          </div>
-          <div class="w-47 profile-card" style="background-color: #003366">
-            <div class="profile-card">
-              <div class="profile-card-content profile-card-github">
-                <span class="iconify" data-inline="false" data-icon="akar-icons:github-fill" style="font-size: 60px; color: #FE0760; padding-bottom: 15px;"></span>
-                <h6 style="padding-bottom: 15px;">GitHub Profile</h6>
-                <div class="profile-data d-flex" style="align-items: center;">
-                  <div class="profile-section">
-                    <p> <span class="iconify" data-inline="false" data-icon="si-glyph:champion-cup" style="font-size: 18px; color: #FE0760;"></span> PUBLIC REPOS</p>
-                  </div>
-                  <div class="profile-score">
-                    <p><%= @user.github_profile.public_repos %></p>
-                  </div>
-                </div>
-                <div class="profile-data d-flex" style="align-items: center;">
-                  <div class="profile-section">
-                    <p> <span class="iconify" data-inline="false" data-icon="si-glyph:champion-cup" style="font-size: 18px; color: #FE0760;"></span> PUBLIC GISTS</p>
-                  </div>
-                  <div class="profile-score">
-                    <p><%= @user.github_profile.public_gists %></p>
-                  </div>
-                </div>
-                <div class="profile-data d-flex" style="align-items: center;">
-                  <div class="profile-section">
-                    <p>  FOLLOWERS</p>
-                  </div>
-                  <div class="profile-score">
-                    <p><%= @user.github_profile.followers %></p>
-                  </div>
-                </div>
-                <div class="profile-data d-flex" style="align-items: center;">
-                  <div class="profile-section">
-                    <p> FOLLOWING</p>
-                  </div>
-                  <div class="profile-score">
-                    <p><%= @user.github_profile.following %> </p>
-                  </div>
-                </div>
-                <div class="profile-data d-flex" style="align-items: center;">
-                  <div class="profile-section">
-                    <p> JOINED GITHUB</p>
-                  </div>
-                  <div class="profile-score">
-                    <p><%= @user.github_profile.joined_github %>  </p>
-                  </div>
+                  <% end %>
                 </div>
               </div>
             </div>
-          </div>
-      <% else %>
-        <%= link_to "Add external profiles", edit_profile_path, :class => "btn-edit-profile" %>
+          <% end %>
+          <% if @user.github_profile %>
+            <div class="w-47 profile-card" style="background-color: #003366">
+              <div class="profile-card">
+                <div class="profile-card-content profile-card-github">
+                  <span class="iconify" data-inline="false" data-icon="akar-icons:github-fill" style="font-size: 60px; color: #FE0760; padding-bottom: 15px;"></span>
+                  <h6 style="padding-bottom: 15px;">GitHub Profile</h6>
+                  <div class="profile-data d-flex" style="align-items: center;">
+                    <div class="profile-section">
+                      <p> <span class="iconify" data-inline="false" data-icon="si-glyph:champion-cup" style="font-size: 18px; color: #FE0760;"></span> PUBLIC REPOS</p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.github_profile.public_repos %></p>
+                    </div>
+                  </div>
+                  <div class="profile-data d-flex" style="align-items: center;">
+                    <div class="profile-section">
+                      <p> <span class="iconify" data-inline="false" data-icon="si-glyph:champion-cup" style="font-size: 18px; color: #FE0760;"></span> PUBLIC GISTS</p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.github_profile.public_gists %></p>
+                    </div>
+                  </div>
+                  <div class="profile-data d-flex" style="align-items: center;">
+                    <div class="profile-section">
+                      <p>  FOLLOWERS</p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.github_profile.followers %></p>
+                    </div>
+                  </div>
+                  <div class="profile-data d-flex" style="align-items: center;">
+                    <div class="profile-section">
+                      <p> FOLLOWING</p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.github_profile.following %> </p>
+                    </div>
+                  </div>
+                  <div class="profile-data d-flex" style="align-items: center;">
+                    <div class="profile-section">
+                      <p> JOINED GITHUB</p>
+                    </div>
+                    <div class="profile-score">
+                      <p><%= @user.github_profile.joined_github %>  </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+      <%# else %>
+        <%#= link_to "Add external profiles", edit_profile_path, :class => "btn-edit-profile" %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
I noticed that - when we click on "add external profile" - the path-cards don't match the current ones (since the user was redirected to `profiles/:username/edit` where the path cards were a copy of the old show page). 

I used this opportunity to improve the UX in general by skipping the `profiles/:username/edit` page (everything happens on `profiles/:username/show`) such that now it's is possible to add only one profile at once.

And some minor design changes.

![external_profiles gif](https://user-images.githubusercontent.com/60707819/111005342-ec699500-838a-11eb-89b3-8aa199f77baa.gif)

