### PR TITLE
same card-height

### DIFF
--- a/app/assets/stylesheets/components/_profile_card.scss
+++ b/app/assets/stylesheets/components/_profile_card.scss
@@ -146,3 +146,7 @@
   margin-right: 4rem;
   margin-bottom: 2rem;
 }
+
+.profile-card-height {
+  height: 350px !important;
+}

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -86,8 +86,8 @@ OF THE CARDS CAN HAPPEN BEFORE THAT DECISION. -->
       <% if @user.codewars_profile || @user.github_profile %>
         <div class="d-flex justify-content-between">
           <% if @user.codewars_profile %>
-            <div class="w-47 profile-card" style="background-color: #003366">
-              <div class="profile-card">
+            <div class="w-47 profile-card profile-card-height" style="background-color: #003366">
+              <div class="profile-card profile-card-height">
                 <div class="profile-card-content codewars">
                   <div class="icon-profile">
                     <!-- <span class="iconify" data-inline="false" data-icon="cib:codewars" style="font-size: 60px; color: #FE0760; padding-bottom: 15px;"></span> -->
@@ -169,8 +169,8 @@ OF THE CARDS CAN HAPPEN BEFORE THAT DECISION. -->
             </div>
           <% end %>
           <% if @user.github_profile %>
-            <div class="w-47 profile-card" style="background-color: #003366">
-              <div class="profile-card">
+            <div class="w-47 profile-card profile-card-height" style="background-color: #003366">
+              <div class="profile-card profile-card-height">
                 <div class="profile-card-content profile-card-github">
                   <!-- <span class="iconify" data-inline="false" data-icon="akar-icons:github-fill" style="font-size: 60px; color: #FE0760; padding-bottom: 15px;"></span> -->
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1em" height="1em" style="font-size: 60px; color: rgb(254, 7, 96); padding-bottom: 15px; transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24" class="iconify" data-inline="false" data-icon="akar-icons:github-fill"><g fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385c.6.105.825-.255.825-.57c0-.285-.015-1.23-.015-2.235c-3.015.555-3.795-.735-4.035-1.41c-.135-.345-.72-1.41-1.23-1.695c-.42-.225-1.02-.78-.015-.795c.945-.015 1.62.87 1.845 1.23c1.08 1.815 2.805 1.305 3.495.99c.105-.78.42-1.305.765-1.605c-2.67-.3-5.46-1.335-5.46-5.925c0-1.305.465-2.385 1.23-3.225c-.12-.3-.54-1.53.12-3.18c0 0 1.005-.315 3.3 1.23c.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23c.66 1.65.24 2.88.12 3.18c.765.84 1.23 1.905 1.23 3.225c0 4.605-2.805 5.625-5.475 5.925c.435.375.81 1.095.81 2.22c0 1.605-.015 2.895-.015 3.3c0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" fill="currentColor"></path></g></svg>


### PR DESCRIPTION
Currently the height is determined by the content of the card, but there are also a number of other height attributes in the various css classes that are at play, that partially or fully override each other.
So now I have added the class 
.profile-card-height {
  height: 350px !important;
}
I personally I prefer it the way it was before:
- For one, the optimal card height depends on whether the codewars profile has one or two languages (jasonheeps has one, so I optimized it for that). 
- Secondly the shadow vertical offset is no longer working properly this way (and I have no idea what causes this offset in the first place, so I cannot adapt it. Maybe @sabinacuccibar knows, then that's something she could adapt).
- And thirdly I think the box adapting to the content somehow makes more sense.

But it's up to you. I don't have a strong opinion in either direction.

![Bildschirmfoto 2021-03-13 um 12 57 36](https://user-images.githubusercontent.com/17951950/111029206-b1537a00-83fb-11eb-96d9-d34bcaa486c0.png)
